### PR TITLE
Discussions belong to a category

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Project;
+use App\Models\Category;
 use App\Services\MessageService;
 use App\Services\ProjectService;
 use App\Http\Requests\StoreProjectRequest;
@@ -29,7 +30,9 @@ class ProjectController extends Controller
         $this->authorize('view', $project);
         $project->load('members');
 
-        return view('projects.single', ['project' => $project]);
+        $categories = Category::all();
+
+        return view('projects.single', ['project' => $project, 'categories' => $categories]);
     }
 
     public function store(StoreProjectRequest $request)

--- a/app/Http/Requests/ValidateDiscussionCreation.php
+++ b/app/Http/Requests/ValidateDiscussionCreation.php
@@ -30,7 +30,7 @@ class ValidateDiscussionCreation extends FormRequest
             'draft'               => 'required|boolean',
             'discussionable_type' => 'required|string|in:project,team,office',
             'discussionable_id'   => 'required|integer',
-            'category_id'         => 'required|integer|exists:categories,id'
+            'category_id'         => 'required|integer|exists:categories,id',
         ];
     }
 }

--- a/app/Http/Requests/ValidateDiscussionCreation.php
+++ b/app/Http/Requests/ValidateDiscussionCreation.php
@@ -30,6 +30,7 @@ class ValidateDiscussionCreation extends FormRequest
             'draft'               => 'required|boolean',
             'discussionable_type' => 'required|string|in:project,team,office',
             'discussionable_id'   => 'required|integer',
+            'category_id'         => 'required|integer|exists:categories,id'
         ];
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class Category extends Model
+{
+    use LogsActivity;
+
+    public function discussions()
+    {
+        return $this->hasMany(\App\Models\Discussion::class);
+    }
+}

--- a/app/Models/Discussion.php
+++ b/app/Models/Discussion.php
@@ -9,5 +9,10 @@ class Discussion extends Model
 {
     use LogsActivity;
 
-    protected $fillable = ['name', 'content', 'raw_content', 'posted_by', 'archived', 'draft', 'discussionable_type', 'discussionable_id'];
+    protected $fillable = ['name', 'content', 'raw_content', 'posted_by', 'archived', 'draft', 'discussionable_type', 'discussionable_id', 'category_id'];
+
+    public function category()
+    {
+        return $this->belongsTo(\App\Models\Category::class);
+    }
 }

--- a/app/Repositories/DiscussionRepository.php
+++ b/app/Repositories/DiscussionRepository.php
@@ -18,6 +18,7 @@ class DiscussionRepository
         return $this->model->create([
             'name'                => $data['name'],
             'content'             => $data['content'],
+            'category_id'         => $data['category_id'],
             'raw_content'         => $data['raw_content'],
             'draft'               => $data['draft'],
             'posted_by'           => auth()->user()->id,

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -4,6 +4,6 @@ use Faker\Generator as Faker;
 
 $factory->define(\App\Models\Category::class, function (Faker $faker) {
     return [
-        'name' => $faker->name
+        'name' => $faker->name,
     ];
 });

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(\App\Models\Category::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name
+    ];
+});

--- a/database/factories/DiscussionFactory.php
+++ b/database/factories/DiscussionFactory.php
@@ -13,13 +13,13 @@ $factory->define(\App\Models\Discussion::class, function (Faker $faker) {
         'draft'                 => false,
         'discussionable_type'   => 'project',
         'discussionable_id'     => function () {
-                                        return factory(\App\Models\Project::class)->create()->id;
-                                    },
+            return factory(\App\Models\Project::class)->create()->id;
+        },
         'posted_by'             => function () {
-                                        return factory(\App\Models\User::class)->create()->id;
-                                    },
+            return factory(\App\Models\User::class)->create()->id;
+        },
         'category_id'           => function () {
-                                        return factory(\App\Models\Category::class)->create()->id;
-                                    },
+            return factory(\App\Models\Category::class)->create()->id;
+        },
     ];
 });

--- a/database/factories/DiscussionFactory.php
+++ b/database/factories/DiscussionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(\App\Models\Discussion::class, function (Faker $faker) {
+    $fakeHeading = $faker->word;
+    $fakeBoldWord = $faker->word;
+
+    return [
+        'name'                  => $faker->name,
+        'content'               => '<h1>'. $fakeHeading .'</h1><p>And some <strong>'. $fakeBoldWord .'</strong></p>',
+        'raw_content'           => '{"ops":[{"insert":"'. $fakeHeading .'"},{"attributes":{"header":1},"insert":"\n"},{"insert":"And some "},{"attributes":{"bold":true},"insert":"'. $fakeBoldWord .'"},{"insert":"\n"}]}',
+        'draft'                 => false,
+        'discussionable_type'   => 'project',
+        'discussionable_id'     => function () {
+                                        return factory(\App\Models\Project::class)->create()->id;
+                                    },
+        'posted_by'             => function () {
+                                        return factory(\App\Models\User::class)->create()->id;
+                                    },
+        'category_id'           => function () {
+                                        return factory(\App\Models\Category::class)->create()->id;
+                                    },
+    ];
+});

--- a/database/migrations/2017_02_15_045815_create_discussions_table.php
+++ b/database/migrations/2017_02_15_045815_create_discussions_table.php
@@ -23,6 +23,7 @@ class CreateDiscussionsTable extends Migration
             $table->boolean('draft')->default(true);
             $table->string('discussionable_type')->comment('office, team or projects');
             $table->integer('discussionable_id')->unsigned();
+            $table->integer('category_id')->unsigned();
             $table->foreign('posted_by')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });

--- a/database/migrations/2018_10_06_181159_create_categories_table.php
+++ b/database/migrations/2018_10_06_181159_create_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('categories');
+    }
+}

--- a/database/migrations/2018_10_06_185643_set_category_foreign_key_in_discussions_table.php
+++ b/database/migrations/2018_10_06_185643_set_category_foreign_key_in_discussions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class SetCategoryForeignKeyInDiscussionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('discussions', function (Blueprint $table) {
+            $table->foreign('category_id')->references('id')->on('categories');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('discussions', function (Blueprint $table) {
+            $table->dropForeign('category_id');
+        });
+    }
+}

--- a/database/seeds/CategorySeeder.php
+++ b/database/seeds/CategorySeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Category;
+use Illuminate\Database\Seeder;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Category::create([
+            'name'       => 'Suggestion',
+        ]);
+
+        Category::create([
+            'name'       => 'Issue',
+        ]);
+
+        Category::create([
+            'name'       => 'Other',
+        ]);
+
+    }
+}

--- a/database/seeds/CategorySeeder.php
+++ b/database/seeds/CategorySeeder.php
@@ -23,6 +23,5 @@ class CategorySeeder extends Seeder
         Category::create([
             'name'       => 'Other',
         ]);
-
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -15,5 +15,6 @@ class DatabaseSeeder extends Seeder
         $this->call(RoleTableSeeder::class);
         $this->call(AdminUserSeeder::class);
         $this->call(HeadquarterOfficeSeeder::class);
+        $this->call(CategorySeeder::class);
     }
 }

--- a/resources/assets/js/components/forms/createDiscussionForm.vue
+++ b/resources/assets/js/components/forms/createDiscussionForm.vue
@@ -9,6 +9,15 @@
     </div>
     <div class="p-4 bg-grey-lighter">
       <label class="block uppercase tracking-wide text-grey-darker text-xs font-bold mb-2" for="grid-first-name">
+        Category <span class="text-grey capitalize">(required)</span>
+      </label>
+      <select class="appearance-none block w-full bg-white text-grey-darker border border-grey-lighter rounded py-3 px-4" v-model="categoryId">
+        <option value="" disabled>Choose one</option>
+        <option :value="category.id" v-for="category in categories">{{ category.name }}</option>
+      </select>
+    </div>
+    <div class="p-4 bg-grey-lighter">
+      <label class="block uppercase tracking-wide text-grey-darker text-xs font-bold mb-2" for="grid-first-name">
         Body <span class="text-grey capitalize">(required)</span>
       </label>
       <div id="editor" class="h-80 bg-white">
@@ -45,6 +54,10 @@ export default {
       required: true,
       type: Boolean
     },
+    categories: {
+      required: true, 
+      type: Array
+    },
     resourceId: {
       required: true,
       type: Number
@@ -56,7 +69,8 @@ export default {
   },
   data: () => ({
     quill: null,
-    name: ''
+    name: '',
+    categoryId: '',
   }),
   mounted () {
     this.quill = new Quill('#editor', options)
@@ -65,6 +79,7 @@ export default {
     savePost (draft = true) {
       axios.post('/discussions', {
         name: this.name,
+        category_id: this.categoryId,
         content: this.quill.root.innerHTML,
         raw_content: JSON.stringify(this.quill.getContents()),
         draft: draft,
@@ -73,6 +88,7 @@ export default {
       })
       .then((response) => {
         this.name = ''
+        this.categoryId = ''
         this.quill.setContents([])
         EventBus.$emit('notification', response.data.message, response.data.status)
         this.$emit('close')

--- a/resources/assets/js/components/partials/discussionBoard.vue
+++ b/resources/assets/js/components/partials/discussionBoard.vue
@@ -1,6 +1,6 @@
 <template>
 <div :class="{'hidden': (activeTab != 'discussions')}" class="w-full">
-  <create-discussion-form :resourceId="resource.id" :resourceType="resourceType" @close="closeCreateDiscussionForm" :form-shown="createDiscussionFormShown"></create-discussion-form>
+  <create-discussion-form :categories="categories" :resourceId="resource.id" :resourceType="resourceType" @close="closeCreateDiscussionForm" :form-shown="createDiscussionFormShown"></create-discussion-form>
   <button @click="showCreateDiscussionForm" class="no-underline p-3 my-4 bg-white text-base text-teal rounded shadow">Create New Post</button>
   <div class="w-full bg-white shadow-md flex flex-row flex-wrap rounded mt-8">
     <a href="#" class="flex flex-row items-center px-6 py-4 no-underline">
@@ -78,6 +78,10 @@ export default {
     activeTab: {
       required: true,
       type: String
+    },
+    categories: {
+      required: true,
+      type: Array
     }
   },
   data: () => ({

--- a/resources/assets/js/components/projects/single.vue
+++ b/resources/assets/js/components/projects/single.vue
@@ -21,7 +21,7 @@
 
     <div class="flex flex-row flex-wrap justify-start">
       <taskBoard resourceType="project" :resource="project"  :activeTab="active"></taskBoard>
-      <discussionBoard resourceType="project" :resource="project" :activeTab="active"></discussionBoard>
+      <discussionBoard resourceType="project" :resource="project" :activeTab="active" :categories="categories"></discussionBoard>
       <messagesBoard resourceType="project" :resource="project" :activeTab="active"></messagesBoard>
       <!-- <messagesBoard resourceType="projects" :resource="project"></messagesBoard>
       <schedule resourceType="projects" :resource="project"></schedule>
@@ -45,7 +45,7 @@ export default {
   components: {
     taskBoard, discussionBoard, messagesBoard, schedule, files, activity, addMemberForm, tabMenu
   },
-  props: ['project'],
+  props: ['project', 'categories'],
   data: () => ({
     addMemberFormShown: false,
     active: 'tasks',

--- a/resources/views/projects/single.blade.php
+++ b/resources/views/projects/single.blade.php
@@ -2,7 +2,7 @@
 
 @slot('title') Single Resource View @endslot
 
-<single :project="{{ $project }}"></single>
+<single :project="{{ $project }}" :categories="{{ json_encode($categories) }}"></single>
 
 @slot('script')
 <script src="//{{ Request::getHost() }}:6001/socket.io/socket.io.js"></script>

--- a/tests/Feature/DiscussionTest.php
+++ b/tests/Feature/DiscussionTest.php
@@ -11,11 +11,13 @@ class DiscussionTest extends TestCase
     public function user_with_permission_can_create_new_discussion()
     {
         $project = factory(\App\Models\Project::class)->create();
+        $category = factory(\App\Models\Category::class)->create();
         $permission = Permission::create(['name' => 'create discussion.project->' . $project->id]);
         $this->user->givePermissionTo($permission);
 
         $this->actingAs($this->user)->post('discussions', [
             'name'                => 'New article',
+            'category_id'         => $category->id,
             'content'             => '<h1>Big heading</h1><p>And some <strong>bold text</strong></p>',
             'raw_content'         => '{"ops":[{"insert":"Big Heading"},{"attributes":{"header":1},"insert":"\n"},{"insert":"And some "},{"attributes":{"bold":true},"insert":"bold text"},{"insert":"\n"}]}',
             'draft'               => false,
@@ -46,10 +48,12 @@ class DiscussionTest extends TestCase
     public function user_without_permission_cant_create_new_discussion()
     {
         $project = factory(\App\Models\Project::class)->create();
+        $category = factory(\App\Models\Category::class)->create();
         Permission::create(['name' => 'create discussion.project->' . $project->id]);
 
         $this->actingAs($this->user)->post('discussions', [
             'name'                => 'New article',
+            'category_id'         => $category->id,
             'content'             => '<h1>Big heading</h1><p>And some <strong>bold text</strong></p>',
             'raw_content'         => '{"ops":[{"insert":"Big Heading"},{"attributes":{"header":1},"insert":"\n"},{"insert":"And some "},{"attributes":{"bold":true},"insert":"bold text"},{"insert":"\n"}]}',
             'draft'               => false,
@@ -58,5 +62,14 @@ class DiscussionTest extends TestCase
         ])->assertJsonFragment([
             'status'              => 'error',
         ]);
+    }
+
+    /** @test **/
+    public function discussions_belongs_to_a_category()
+    {
+        $category = factory(\App\Models\Category::class)->create(['name' => 'Fake category']);
+        $discussion = factory(\App\Models\Discussion::class)->create(['category_id' => $category]);
+
+        $this->assertEquals('Fake category', $discussion->category->name);
     }
 }


### PR DESCRIPTION
Attempted to resolve issue #167, guided by the suggested improvements of @Hasnayeen regarding my previous pull request #168. 

Every discussion now has a category. However, I later realized that categories might be project bound, now they are just generalized amongst all projects. Maybe something to refactor later?

Another thing, when I was testing the frontend I noticed I got an error that the "create discussion.project->1" permission did not exist. This is due to the rule within app\Http\Requests\ValidateDiscussionCreation that uses the following authorization logic:
`return auth()->user()->hasPermissionTo('create discussion.' . request('discussionable_type') . '->' . request('discussionable_id'));`

However, the create discussion.project->1 permission is not available in the database. I was wondering which solution you had in mind.

Best, 

John