### PR TITLE
[#177] Feature tests for reservation invite

### DIFF
--- a/tests/Feature/RegistrationInvitationTest.php
+++ b/tests/Feature/RegistrationInvitationTest.php
@@ -70,7 +70,6 @@ class RegistrationInvitationTest extends TestCase
     public function email_needs_to_be_supplied_in_request()
     {
         $this->expectException(ErrorException::class);
-        $this->expectExceptionMessage('Trying to get property \'email\' of non-object');
 
         $this->actingAs($this->user);
         $this->post(self::$endpoint, []);

--- a/tests/Feature/RegistrationInvitationTest.php
+++ b/tests/Feature/RegistrationInvitationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use ErrorException;
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Auth\AuthenticationException;
+
+class RegistrationInvitationTest extends TestCase
+{
+    private static $endpoint = 'register/invite';
+
+    public function setUp()
+    {
+        parent::setUp();
+        Mail::fake();
+    }
+
+    /**
+     * @test
+     */
+    public function authenticated_user_can_send_invitation()
+    {
+        $this->actingAs($this->user);
+        $email = 'john.doe@example.com';
+
+        $this->assertDatabaseMissing('users', ['email' => $email]);
+
+        $response = $this->post(self::$endpoint, ['email' => $email]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'status'  => 'success',
+            'message' => 'Invitation sent successfully',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function guest_can_not_send_invitation()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Unauthenticated');
+        $this->post(self::$endpoint, []);
+    }
+
+    /**
+     * @test
+     */
+    public function invitation_is_not_sent_if_email_is_in_database_already()
+    {
+        $this->actingAs($this->user);
+        $user = factory(User::class)->create(['email' => 'john.doe@example.com']);
+
+        $response = $this->post(self::$endpoint, ['email' => $user->email]);
+
+        $response->assertStatus(409);
+        $response->assertJson([
+            'status'  => 'error',
+            'message' => 'Email already exist',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function email_needs_to_be_supplied_in_request()
+    {
+        $this->expectException(ErrorException::class);
+        $this->expectExceptionMessage('Trying to get property \'email\' of non-object');
+
+        $this->actingAs($this->user);
+        $this->post(self::$endpoint, []);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use App\Models\User;
 use Spatie\Permission\Models\Role;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\Models\Permission;
@@ -15,6 +16,11 @@ abstract class TestCase extends BaseTestCase
     use CreatesApplication;
     use DatabaseMigrations;
     use DatabaseTransactions;
+
+    /**
+     * @var User
+     */
+    protected $user;
 
     public function setUp()
     {


### PR DESCRIPTION
- Created test for API endpoint /reservation/invite
- Tested scenarios:
	- authenticated user can send invitation
	- invitation is send only to user not already registered
	- guests can't send invitations
	- email is being required