### PR TITLE
Fixed an issue where going to the admin page as a guest resulted in an error that stated that route 'home' does not exist

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ Route::get('register/{token}', 'Auth\RegisterController@showRegistrationForm');
 Route::post('register/{token}', 'Auth\RegisterController@confirmNewRegistration');
 
 Route::group(['middleware' => 'auth'], function () {
-    Route::get('/', 'HomeController@index');
+    Route::get('/', 'HomeController@index')->name('home');
 
     /**********************************
         Project

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
@@ -48,5 +49,17 @@ class UserTest extends TestCase
         ]);
         $this->assertDatabaseHas('users', ['email' => 'new@email.com']);
         password_verify('new_password', $this->user->password);
+    }
+
+    /** @test */
+    public function guest_can_not_see_admin_page()
+    {
+        $guest_user = factory(User::class)->create();
+        $guest_role = Role::create(['name' => 'guest']);
+        $guest_user->assignRole($guest_role);
+
+        $this->expectException(\Spatie\Permission\Exceptions\UnauthorizedException::class);
+
+        $this->actingAs($guest_user)->get('admin');
     }
 }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Feature;
 
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
+use Spatie\Permission\Models\Role;
 use Illuminate\Support\Facades\Storage;
 
 class UserTest extends TestCase


### PR DESCRIPTION
Fixed an issue where going to the admin page as a guest resulted in an error that stated that route 'home' does not exist. Also added a test that checks if the proper exceptions gets thrown when going to that page.


This issue can easily be seen on the demo page https://goodworkfor.life/ and logging in as guest then clicking on the admin page in the dropdown.