### PR TITLE
Fixed an issue where going to an undefined route would throw an error

### DIFF
--- a/app/Http/Middleware/LocalizationMiddleware.php
+++ b/app/Http/Middleware/LocalizationMiddleware.php
@@ -20,7 +20,9 @@ class LocalizationMiddleware
         app()->setLocale($locale);
         $response = $next($request);
 
-        $file = config('locale.route_to_file.' . $request->route()->uri);
+        $uri = $request->route() ? $request->route()->uri : '';
+        $file = config('locale.route_to_file.' . $uri);
+
         if (! is_null($file)) {
             $localeData = array_merge(Lang::get('navbar', [], $locale), Lang::get($file, [], $locale));
             $localeString = json_encode($localeData);


### PR DESCRIPTION
Fixed an issue where going to an undefined route would throw an error.

Any undefined route would throw a 500 error. Now it throws an appropriate 404 error.