### PR TITLE
Showed correct comments for tasks (#205, #238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `LocalizationMiddleware` & `locale` config ([issue-211](https://github.com/iluminar/goodwork/issues/211))
 - Added `lang` column in `users` table ([issue-211](https://github.com/iluminar/goodwork/issues/211))
 - Added `localize` filter in global Vue ([issue-211](https://github.com/iluminar/goodwork/issues/211))
+- Added comment option to tasks ([issue-205](https://github.com/iluminar/goodwork/issues/205))
 
 ## v0.7 (2018-10-13)
 

--- a/resources/assets/js/components/partials/commentBox.vue
+++ b/resources/assets/js/components/partials/commentBox.vue
@@ -41,7 +41,7 @@ export default {
       required: true,
       type: Object
     },
-    discussionDetailsShown: {
+    detailsShown: {
       required: true,
       type: Boolean
     }

--- a/resources/assets/js/components/partials/discussionDetails.vue
+++ b/resources/assets/js/components/partials/discussionDetails.vue
@@ -30,7 +30,7 @@
     </div>
     <div v-html="discussion.content" class="py-8 text-grey-darkest"></div>
 
-    <comment-box resourceType="discussion" :resource="discussion" :discussionDetailsShown="discussionDetailsShown"></comment-box>
+    <comment-box resourceType="discussion" :resource="discussion" :detailsShown="discussionDetailsShown"></comment-box>
   </div>
 
   <div @click="closeDiscussionDetails" class="h-screen w-screen fixed pin bg-grey-darkest opacity-25"></div>

--- a/resources/assets/js/components/partials/taskBoard.vue
+++ b/resources/assets/js/components/partials/taskBoard.vue
@@ -2,11 +2,11 @@
 <div :class="{'hidden': (activeTab != 'tasks')}" class="w-full">
   <create-task-form :resource="resource" :resourceType="resourceType" :form-shown="createTaskFormShown" @close="closeCreateTaskForm"></create-task-form>
 
-  <task-details v-if="task" :index="index" :task="task" :task-details-shown="taskDetailsShown" @delete="deleteTask" @close="closeTaskDetails"></task-details>
+  <task-details v-if="task" :index="index" :task="task" :taskDetailsShown="taskDetailsShown" @delete="deleteTask" @close="closeTaskDetails"></task-details>
 
   <button @click="showCreateTaskForm" class="no-underline p-3 my-4 bg-white text-base text-teal rounded shadow">{{ 'Create Task' | localize }}</button>
   <div class="flex flex-row flex-wrap md:-mx-1/20 lg:-mx-1/60 xl:-mx-1/40">
-    <div v-for="(task, index) in tasks" @click="showTaskDetails(task.id)" class="bg-white rounded shadow my-4 md:mx-1/20 lg:mx-1/60 xl:mx-1/40 flex flex-row p-4 no-underline items-center w-full md:w-2/5 lg:w-3/10 xl:w-1/5 h-24 border-l-2 border-teal cursor-pointer">
+    <div v-for="(task, index) in tasks" @click="showTaskDetails(index)" :key="index" class="bg-white rounded shadow my-4 md:mx-1/20 lg:mx-1/60 xl:mx-1/40 flex flex-row p-4 no-underline items-center w-full md:w-2/5 lg:w-3/10 xl:w-1/5 h-24 border-l-2 border-teal cursor-pointer">
       <img v-if="task.assigned_to" :src="generateUrl(task.user.avatar)" class="rounded-full w-8 h-8 mx-2 self-start">
       <i v-else class="fas fa-question-circle fa-2x mx-2 self-start text-grey-darker"></i>
       <div class="w-4/5 text-grey-darker text-left pl-2 flex flex-col justify-between h-full">
@@ -43,23 +43,9 @@ export default {
     createTaskFormShown: false,
     taskDetailsShown: false,
     tasks: [],
-    task: null,
+    task: {},
     index: null
   }),
-  created: function () {
-    axios.get('/tasks', {
-      params: {
-        resource_type: this.resourceType,
-        resource_id: this.resource.id
-      }
-    })
-      .then((response) => {
-        this.tasks = response.data.tasks
-      })
-      .catch((error) => {
-        console.log(error)
-      })
-  },
   methods: {
     showCreateTaskForm () {
       this.createTaskFormShown = true
@@ -68,22 +54,56 @@ export default {
       (newTask) ? this.tasks.push(newTask) : null
       this.createTaskFormShown = false
     },
-    showTaskDetails (id) {
-      axios.get('/tasks/' + id)
+    getAllTasks () {
+      if (this.activeTab === 'tasks' && this.tasks.length < 1) {
+        axios.get('/tasks', {
+          params: {
+            resource_type: this.resourceType,
+            resource_id: this.resource.id
+          }
+        })
         .then((response) => {
-          this.task = response.data.task
+          this.tasks = response.data.tasks
         })
         .catch((error) => {
-          console.log(error)
+          console.log(error.response.data.message)
         })
-      this.taskDetailsShown = true
+      }
+    },
+    showTaskDetails (index) {
+      this.index = index
+      this.task = this.tasks[index]
+      if (typeof this.task.user.username === 'undefined') {
+        axios.get('/users')
+        .then((response) => {
+          for (let i = 0; i < response.data.data.length; i++) {
+            if (response.data.data[i].id === this.task.user.id) {
+              this.task.user.username = response.data.data[i].username
+              this.task.user.name = response.data.data[i].name
+            }
+          }
+          this.taskDetailsShown = true
+        })
+        .catch((error) => {
+          console.log(error.response.data.message)
+        })
+      } else {
+        this.taskDetailsShown = true
+      }
     },
     closeTaskDetails () {
       this.taskDetailsShown = false
+      this.task = {}
     },
-    deleteTask (index) {
+    deleteTask(index) {
       this.tasks.splice(index, 1)
     }
+  },
+  watch: {
+    activeTab: 'getAllTasks'
+  },
+  created () {
+    this.getAllTasks()
   }
 }
 </script>

--- a/resources/assets/js/components/partials/taskDetails.vue
+++ b/resources/assets/js/components/partials/taskDetails.vue
@@ -1,6 +1,6 @@
 <template>
-<div>
-  <div :class="{'hidden': !taskDetailsShown}" class="absolute container mx-auto md:w-3/4 lg:2/3 xl:w-1/2 xxl:w-2/5 bg-white rounded shadow-lg z-10 pt-4 pb-8" style="top: 12vh;left: 0;right: 0;">
+<div v-if="taskDetailsShown">
+  <div class="absolute container mx-auto md:w-3/4 lg:2/3 xl:w-1/2 xxl:w-2/5 bg-white rounded shadow-lg z-10 pt-4 pb-8" style="top: 12vh;left: 0;right: 0;">
     <div class="flex flex-row justify-between px-8 relative">
       <div @click="closeTaskDetails" class="cursor-pointer">
         <i class="fas fa-arrow-left text-base text-grey-dark"></i>
@@ -75,7 +75,7 @@
       </div>
     </div>
     <div class="px-4">
-      <comment-box resourceType="task" :resource="task" :discussionDetailsShown="taskDetailsShown"></comment-box>
+      <comment-box resourceType="task" :resource="task" :detailsShown="taskDetailsShown"></comment-box>
     </div>
   </div>
   <div @click="closeTaskDetails" :class="{'hidden': !taskDetailsShown}" class="h-screen w-screen fixed pin bg-grey-darkest opacity-25"></div>
@@ -99,8 +99,7 @@ export default {
       type: Object
     },
     index: {
-      required: false,
-      type: Number
+      required: true
     }
   },
   data: () => ({


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/iluminar/goodwork/wiki/Contribution-Guideline) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch**. Also you should start *your branch* off *dev branch*.
- [ ] Check you have added tests that prove your fix is effective or that your feature works.
- [ ] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check you added any notable changes to the `CHANGELOG.md` file.

### Description
Issue #205 requested that a comments form be added to the tasks detail modal, which was completed in PR #238.

However, this would only show the comments for the first task viewed. Any subsequent tasks clicked on would still show the comments from the first task.

These commits now allows for the correct comments to be shown for the relevant task.

💔Thank you!