### PR TITLE
Fix for Long line in message overflow out of box #255

### DIFF
--- a/resources/assets/js/components/partials/message.vue
+++ b/resources/assets/js/components/partials/message.vue
@@ -29,7 +29,7 @@
       </div>
     </div>
     <div class="mx-2">
-      <div  class="rounded-lg p-3 w-64 leading-normal text-grey-darkest"
+      <div  class="rounded-lg p-3 w-64 leading-normal text-grey-darkest wrap-word"
         :class="[(message.user_id === user.id) ? 'bg-teal-lightest rounded-tr-none' : 'bg-pink-lightest rounded-tl-none']">
         {{ message.body }}
       </div>

--- a/resources/assets/sass/custom.scss
+++ b/resources/assets/sass/custom.scss
@@ -305,6 +305,11 @@ a.avatar-link:hover {
     overflow-y: hidden;
 }
 
+// word wrapping to avoid overflow
+.wrap-word{
+    word-wrap:break-word;
+}
+
 .homepage {
     padding: 0.8rem 1.5rem;
     .menu-list {


### PR DESCRIPTION

### Description
The message item was overflowing if there was a lot of text so i just added the word-wrapping in scss for the message item .This is how it looks now
![screenshot_20181016_192142](https://user-images.githubusercontent.com/38727945/47021260-b81d2a80-d178-11e8-9a26-41e6a17dfa74.png)


💔Thank you!
