### PR TITLE
Tabmenu: Hide resource names on smaller viewports; fixes #289

### DIFF
--- a/resources/assets/js/components/partials/tabMenu.vue
+++ b/resources/assets/js/components/partials/tabMenu.vue
@@ -3,32 +3,32 @@
       <div @click="activateThisTab('tasks')"
         :class="[(active === 'tasks') ? 'text-teal-dark font-semibold border-teal border-b-2 pb-4 -mb-4' : 'cursor-pointer', 'text-center w-1/6']">
         <font-awesome-icon :icon="faTasks" class="text-2xl"></font-awesome-icon>
-        <span class="block text-xs font-regular pt-2">{{ 'Tasks' | localize }}</span>
+        <span class="hidden md:block text-xs font-regular pt-2">{{ 'Tasks' | localize }}</span>
       </div>
       <div @click="activateThisTab('discussions')"
         :class="[(active === 'discussions') ? 'text-teal-dark font-semibold border-teal border-b-2 pb-4 -mb-4' : 'cursor-pointer', 'text-center w-1/6']">
         <font-awesome-icon :icon="faClipboardList" class="text-2xl"></font-awesome-icon>
-        <span class="block text-xs font-regular pt-2">{{ 'Discussions' | localize }}</span>
+        <span class="hidden md:block text-xs font-regular pt-2">{{ 'Discussions' | localize }}</span>
       </div>
       <div @click="activateThisTab('messages')"
         :class="[(active === 'messages') ? 'text-teal-dark font-semibold border-teal border-b-2 pb-4 -mb-4' : 'cursor-pointer', 'text-center w-1/6']">
         <font-awesome-icon :icon="faComments" class="text-2xl"></font-awesome-icon>
-        <span class="block text-xs font-regular pt-2">{{ 'Messages' | localize }}</span>
+        <span class="hidden md:block text-xs font-regular pt-2">{{ 'Messages' | localize }}</span>
       </div>
       <div @click="activateThisTab('events')"
         :class="[(active === 'events') ? 'text-teal-dark font-semibold border-teal border-b-2 pb-4 -mb-4' : 'cursor-pointer', 'text-center w-1/6']">
         <font-awesome-icon :icon="faCalendarAlt" class="text-2xl"></font-awesome-icon>
-        <span class="block text-xs font-regular pt-2">{{ 'Events' | localize }}</span>
+        <span class="hidden md:block text-xs font-regular pt-2">{{ 'Events' | localize }}</span>
       </div>
       <div @click="activateThisTab('files')"
         :class="[(active === 'files') ? 'text-teal-dark font-semibold border-teal border-b-2 pb-4 -mb-4' : 'cursor-pointer', 'text-center w-1/6']">
         <font-awesome-icon :icon="faFileAlt" class="text-2xl"></font-awesome-icon>
-        <span class="block text-xs font-regular pt-2">{{ 'Files' | localize }}</span>
+        <span class="hidden md:block text-xs font-regular pt-2">{{ 'Files' | localize }}</span>
       </div>
       <div @click="activateThisTab('activities')"
         :class="[(active === 'activities') ? 'text-teal-dark font-semibold border-teal border-b-2 pb-4 -mb-4' : 'cursor-pointer', 'text-center w-1/6']">
         <font-awesome-icon :icon="faBolt" class="text-2xl"></font-awesome-icon>
-        <span class="block text-xs font-regular pt-2">{{ 'Activities' | localize }}</span>
+        <span class="hidden md:block text-xs font-regular pt-2">{{ 'Activities' | localize }}</span>
       </div>
     </div>
 </template>


### PR DESCRIPTION
This PR hides resource names on smaller screen, on medium and larger names are shown.
(Issue #289)

Captures as a reference:

Medium & Larger:
![goodwork-medium](https://user-images.githubusercontent.com/1389199/47140173-494de780-d2c6-11e8-826c-b6538bd607ea.png)

A bit narrower than medium:
![goodwork-smaller](https://user-images.githubusercontent.com/1389199/47140189-523eb900-d2c6-11e8-8696-9c7b7d1a3cbd.png)

A bit more narrower:
![goodwork-smallest](https://user-images.githubusercontent.com/1389199/47140334-a34ead00-d2c6-11e8-9221-50ce4800cee8.png)
