### PR TITLE
Fix errors generated from PR #307 merge

### DIFF
--- a/resources/assets/js/components/partials/messageBox.vue
+++ b/resources/assets/js/components/partials/messageBox.vue
@@ -59,7 +59,7 @@ export default {
   }),
   created () {
     EventBus.$on('show-message-box', this.showMessageBox)
-    axios.get('users')
+    axios.get('/users')
       .then((response) => {
         this.users = response.data.users
       })
@@ -115,7 +115,7 @@ export default {
     selectUserMessage (user) {
       this.selectedUser = user
       this.isDisabled = false
-      axios.get('direct-messages', {
+      axios.get('/direct-messages', {
         params: {
           resource_type: 'user',
           resource_id: user.id

--- a/resources/assets/js/components/partials/taskBoard.vue
+++ b/resources/assets/js/components/partials/taskBoard.vue
@@ -77,10 +77,10 @@ export default {
       if (typeof this.task.user.username === 'undefined') {
         axios.get('/users')
           .then((response) => {
-            for (let i = 0; i < response.data.data.length; i++) {
-              if (response.data.data[i].id === this.task.user.id) {
-                this.task.user.username = response.data.data[i].username
-                this.task.user.name = response.data.data[i].name
+            for (let i = 0; i < response.data.users.length; i++) {
+              if (response.data.users[i].id === this.task.user.id) {
+                this.task.user.username = response.data.users[i].username
+                this.task.user.name = response.data.users[i].name
               }
             }
             this.taskDetailsShown = true


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/iluminar/goodwork/wiki/Contribution-Guideline) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch**. Also you should start *your branch* off *dev branch*.
- [ ] Check you have added tests that prove your fix is effective or that your feature works.
- [ ] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check you added any notable changes to the `CHANGELOG.md` file.

### Description
PR #307 introduced direct messaging functionality. This works fine on top-level pages, but due to missing slashes in the `users` and `direct-messages` requests a 404 error is generated when on a sub-level page (e.g. `/projects/`).

Additionally, PR #307 updated the `/users` API to use "users" rather than "data" in the JSON response generated in `app/Http/Controllers/UserController.php`. This commit stops an error being thrown ("`Uncaught (in promise) TypeError: Cannot read property 'data' of undefined`") when trying to open a task.

💔Thank you!