### PR TITLE
Remove from list when a project/team/office is deleted (VueJS)

### DIFF
--- a/resources/assets/js/pages/home.js
+++ b/resources/assets/js/pages/home.js
@@ -8,5 +8,10 @@ const app = new Vue({
   mixins: [componentMixin],
   components: {
     home
-  }
+  },
+  data: () => ({
+    projects: projects,
+    teams: teams,
+    offices: offices
+  })
 })

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -2,14 +2,20 @@
 
 @slot('title') Home Page @endslot
 
-<home :projects="{{ $projects }}"  :teams="{{ $teams }}"  :offices="{{ $offices }}"></home>
+<home :projects="projects" :teams="teams" :offices="offices"></home>
 
 @slot('script')
 <script>
-    window.errors = <?php echo json_encode($errors->toArray()); ?>
+    window.errors = @php echo json_encode($errors->toArray()); @endphp
 </script>
 <script src="//{{ Request::getHost() }}:6001/socket.io/socket.io.js"></script>
+<script type="text/javascript">
+    var projects = {!! $projects !!}
+    var teams = {!! $teams !!}
+    var offices = {!! $offices !!}
+</script>
 <script src="{{ mix('/js/home.min.js') }}"></script>
+
 @endslot
 
 @endcomponent


### PR DESCRIPTION
### Description
This is a PR resolving an issue with items not being deleted from the UI when they should. 

**MAJOR WARNINGS TO REPO MAINTAINER**

1) This PR resolves the items not being deleted. However, the deletion functions are wrong and delete incorrect items from the UI. For example `this.projects.splice(index, 1)` in `projects.vue` must be replaced in another issue.

2) This issue comes from incorrect model binding. Before you had this:

`<home :projects="{{ $projects }}"  :teams="{{ $teams }}"  :offices="{{ $offices }}"></home>`

**DO NOT** bind PHP variables directly as props. Instead bind them to VUE as I do in the PR. This should be followed in all future code.

Resolves #318