### PR TITLE
Setup PHP GD library on the project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL Description="This image is used to setup Goodwork application"
 
 RUN echo "cgi.fix_pathinfo=0;" > /usr/local/etc/php-fpm.d/php.ini
 
-RUN apt-get update && apt-get -y install zip unzip git && docker-php-ext-install pdo_mysql
+RUN apt-get update && apt-get -y install libpng-dev zip unzip git && docker-php-ext-install pdo_mysql gd
 
 # Set git to use http instead ssh
 RUN git config --global url."https://github.com/".insteadOf git@github.com:

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "type": "application",
     "require": {
         "php": "^7.1.3",
+        "ext-gd": "*",
         "doctrine/dbal": "^2.8",
         "fideloper/proxy": "^4.0",
         "guzzlehttp/guzzle": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82a054f7bee9c86c730c4a2dcd3a754e",
+    "content-hash": "26afe6838bae9b8ba093bd11a2763654",
     "packages": [
         {
             "name": "anahkiasen/underscore-php",
@@ -5811,7 +5811,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "ext-gd": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
We had a problem with the [User tests coverage](https://github.com/iluminar/goodwork/blob/master/tests/Feature/UserTest.php#L46). Because the **Docker image** didn't have the [PHP GD](https://secure.php.net/manual/en/book.image.php) extension installed and we need that to test[ if the user can upload an image](https://github.com/iluminar/goodwork/blob/master/tests/Feature/UserTest.php#L46). I fixed it, adding the libraries dependencies and installing the extension. Now, when any people to follow the[ contributing guide](https://github.com/iluminar/goodwork/blob/master/CONTRIBUTING.md) the tests are not broken. Another thing is when my OS did not have the GD extension the Composer dependencies manager did not complain and now that is required. See the result below:

![screenshot from 2018-10-23 23-07-49](https://user-images.githubusercontent.com/5892371/47402171-a01a4d80-d71a-11e8-99b3-d0e8c695f612.png)

See issue #362