### PR TITLE
[BUGFIX] duplicate key in german translation

### DIFF
--- a/resources/lang/de/admin.php
+++ b/resources/lang/de/admin.php
@@ -6,7 +6,7 @@ return [
     'Activities'                     => 'Aktivitäten',
     'About'                          => 'Über',
     'Roles'                          => 'Rollen',
-    'Roles'                          => 'Rollen',
+    'Role'                           => 'Rolle',
     'Permissions'                    => 'Rechte',
     'Invite New Member'              => 'Neues Mitglied einladen',
     'Add New Role'                   => 'Neue Rolle hinzufügen',


### PR DESCRIPTION
fix german translation so that array does not contain duplicate key 'roles' but instead contains the correct 'role' as in english

