### PR TITLE
Added missing bcmath php extension

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,7 +47,7 @@ services:
     links:
       - db
     working_dir: /var/www
-    command: bash -c "apt-get update && docker-php-ext-install pdo_mysql && php artisan queue:work redis --sleep=1 --tries=1"
+    command: bash -c "apt-get update && docker-php-ext-install pdo_mysql bcmath && php artisan queue:work redis --sleep=1 --tries=1"
     depends_on:
       - php
 


### PR DESCRIPTION
### Description
bcmath php extension is missing in `docker-compose.dev.yml`

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch**. Also you should start *your branch* off *dev branch*.
- [ ] Check you have included issue number in your pr (e.g #23).
- [x] Check you have added tests that prove your fix is effective or that your feature works.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [ ] Check you added any notable changes to the `CHANGELOG.md` file.

