### PR TITLE
Make asset generating URLs respect application's URL Scheme

### DIFF
--- a/app/Base/Providers/AppServiceProvider.php
+++ b/app/Base/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Base\Providers;
 
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
@@ -12,8 +13,10 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(UrlGenerator $url)
     {
+        $url->forceScheme(env('APP_PROTOCOL', "http"));
+
         Relation::morphMap([
             'project'    => 'App\Project\Models\Project',
             'team'       => 'App\Team\Models\Team',

--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,6 @@ return [
                 'STRICT_TRANS_TABLES',
                 'NO_ZERO_IN_DATE',
                 'NO_ZERO_DATE',
-                'NO_AUTO_CREATE_USER',
                 'ERROR_FOR_DIVISION_BY_ZERO',
                 'NO_ENGINE_SUBSTITUTION',
             ],


### PR DESCRIPTION
### Make sure you've reviewed the checklist. (DO NOT REMOVE)
🚨Please review the [guidelines for contributing](https://github.com/iluminar/goodwork/wiki/Contribution-Guideline) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch**. Also you should start *your branch* off *dev branch*.
- [x] Check you have included issue number in your pr (e.g #23).
- [x] Check you have added tests that prove your fix is effective or that your feature works.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] Check you added any notable changes to the `CHANGELOG.md` file.

### Description
- Solves #968 
- Implements an easily accessible way to enforce HTTP/HTTPS for reverse proxy scenarios without hard-coding or modifying existing Blade views
- Backwards compatible with existing installations as it falls back to `HTTP` scheme by default (previous and only behavior)

💔Thank you!
